### PR TITLE
Remove explicit peer dependencies on React

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,11 @@
   },
   "homepage": "https://github.com/netguru/rwr-redux",
   "peerDependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0",
     "react-redux": "^4.4.0",
     "redux": "^3.3.1"
   },
   "dependencies": {
-    "react-webpack-rails": "^0.1.0"
+    "react-webpack-rails": "^0.3.1"
   },
   "devDependencies": {
     "babel-cli": "^6.4.0",


### PR DESCRIPTION
Whilst getting https://github.com/netguru/react_webpack_rails/pull/73 to work, this package was also problematic since it has an explicit peerDependencies on React.

Given that it requires `react-webpack-rails` which has the peerDependencies as well I'd suggest dropping  it here to avoid unnecessary errors because of it.